### PR TITLE
Python: Handle class definitions with empty argument list 

### DIFF
--- a/src/codetext/parser/python_parser.py
+++ b/src/codetext/parser/python_parser.py
@@ -114,7 +114,9 @@ class PythonParser(LanguageParser):
                 argument_list = get_node_text(child).split(',')
                 for arg in argument_list:
                     item = re.sub(r'[^a-zA-Z0-9\_]', ' ', arg).split()
-                    metadata['parameters'][item[0].strip()] = None
+                    # Handle class definitions with empty argument list class ABC()
+                    if len(item) > 0:
+                        metadata['parameters'][item[0].strip()] = None
 
         # get __init__ function
         return metadata

--- a/tests/test_parser/test_python.py
+++ b/tests/test_parser/test_python.py
@@ -59,20 +59,40 @@ class Test_PythonParser(unittest.TestCase):
 
     def test_get_class_metadata(self):
         code_sample = '''
+        class ABC()
+            pass
+            
         class Sample(ABC):
             def __init__(self):
                 pass
 
             def test_sample(self, arg1: str = "string", arg2 = "another_string"):
                 return NotImplement()
+        
+        class DEF(ABC, Sample):
+            pass
         '''
         root = parse_code(code_sample, 'python').root_node
         
-        classes = list(PythonParser.get_class_list(root))[0]
-        metadata = PythonParser.get_class_metadata(classes)
-
+        
+        classes = list(PythonParser.get_class_list(root))
+        self.assertEqual(len(classes), 3)
+        
+        metadata = PythonParser.get_class_metadata(classes[0])
+        self.assertEqual(metadata['parameters'], {})
+        self.assertEqual(metadata['identifier'], 'ABC')
+        
+        
+        metadata = PythonParser.get_class_metadata(classes[1])
         self.assertEqual(metadata['parameters'], {'ABC': None})
         self.assertEqual(metadata['identifier'], 'Sample')
+        
+        
+        metadata = PythonParser.get_class_metadata(classes[2])
+        self.assertEqual(metadata['parameters'], [{'ABC': None}, {'Sample': None}])
+        self.assertEqual(metadata['identifier'], 'DEF')
+        
+        
         
     def test_get_comment_list(self):
         root = self.root_node

--- a/tests/test_parser/test_python.py
+++ b/tests/test_parser/test_python.py
@@ -27,7 +27,6 @@ class Test_PythonParser(unittest.TestCase):
         root = self.root_node
         
         class_list = PythonParser.get_class_list(root)
-        
         self.assertEqual(len(class_list), 1)
 
     def test_get_docstring(self):
@@ -59,7 +58,7 @@ class Test_PythonParser(unittest.TestCase):
 
     def test_get_class_metadata(self):
         code_sample = '''
-        class ABC()
+        class ABC():
             pass
             
         class Sample(ABC):
@@ -69,7 +68,7 @@ class Test_PythonParser(unittest.TestCase):
             def test_sample(self, arg1: str = "string", arg2 = "another_string"):
                 return NotImplement()
         
-        class DEF(ABC, Sample):
+        class ThisIsalsoAclass(ABC, Sample):
             pass
         '''
         root = parse_code(code_sample, 'python').root_node
@@ -89,8 +88,8 @@ class Test_PythonParser(unittest.TestCase):
         
         
         metadata = PythonParser.get_class_metadata(classes[2])
-        self.assertEqual(metadata['parameters'], [{'ABC': None}, {'Sample': None}])
-        self.assertEqual(metadata['identifier'], 'DEF')
+        self.assertEqual(metadata['parameters'], {'ABC': None, 'Sample': None})
+        self.assertEqual(metadata['identifier'], 'ThisIsalsoAclass')
         
         
         


### PR DESCRIPTION
class ABC() ----> {"identifier": "ABC", "parameters": {}}