### PR TITLE
Fix unintentionally overwritten `method_list`

### DIFF
--- a/src/codetext/codetext_cli.py
+++ b/src/codetext/codetext_cli.py
@@ -53,8 +53,8 @@ def parse_file(file_path: str, language: str = None, verbose: bool = False) -> L
         cls_info["code"] = get_node_text(_cls)
 
         cls_method = []
-        method_list = parser.get_function_list(_cls)
-        for method in method_list:
+        current_class_methods = parser.get_function_list(_cls)
+        for method in current_class_methods:
             method_info = parser.get_function_metadata(method)
             method_info['code'] = get_node_text(method)
             cls_method.append(method_info)

--- a/src/codetext/codetext_cli.py
+++ b/src/codetext/codetext_cli.py
@@ -61,7 +61,7 @@ def parse_file(file_path: str, language: str = None, verbose: bool = False) -> L
 
         cls_info["method"] = cls_method
         cls_metadata.append(cls_info)
-        method_list.extend(method_list)
+        method_list.extend(current_class_methods)
 
     fn_list: List = parser.get_function_list(root_node)
     for node in fn_list[:]:


### PR DESCRIPTION
I would like to thank the authors of this repository for their work on this project, which has been invaluable for AI4code projects. However, I found a bug in the code that should not be present.

The error is that the `method_list` variable is overwritten on line 56. This means that the `method_list` variable will only contain the methods of the last extend time.

https://github.com/FSoft-AI4Code/CodeText-parser/blob/bdacdc4cb464fe1d43875dc4cdad1ad5a86e39f9/src/codetext/codetext_cli.py#L49-L64

To fix this error, instead of overwriting the `method_list` variable, I created a new variable, `current_class_methods`, to store the methods of the current class (check out my PR). Then, I extend the `current_class_methods` variable to the `method_list` list safely (line 64). This ensures that the `method_list` list contains all of the methods for all of the classes in the `method_list` list.

Here is the corrected code,

```python

  cls_list = parser.get_class_list(root_node)
  method_list = []
  cls_metadata = []
  for _cls in cls_list:
      cls_info = parser.get_class_metadata(_cls)
      cls_info["code"] = get_node_text(_cls)

      cls_method = []
      current_class_methods = parser.get_function_list(_cls)
      for method in current_class_methods:
          method_info = parser.get_function_metadata(method)
          method_info['code'] = get_node_text(method)
          cls_method.append(method_info)

      cls_info["method"] = cls_method
      cls_metadata.append(cls_info)
      method_list.extend(current_class_methods)

```


